### PR TITLE
refactor: move helpers.ts from github/ to api/ and change imports (#8)

### DIFF
--- a/services/api/helpers.ts
+++ b/services/api/helpers.ts
@@ -1,6 +1,6 @@
 import { apiClient } from "@/services/api";
 import { GITHUB_API_BASE_URL } from "@/constants/github";
-import { GithubReadmeResponse, GithubSearchResponse } from "./types";
+import { GithubReadmeResponse, GithubSearchResponse } from "../github/types";
 
 export const searchGithubRepositories = async (
   page: number

--- a/services/github/githubRepoService.ts
+++ b/services/github/githubRepoService.ts
@@ -1,7 +1,7 @@
 import { MAX_GITHUB_SEARCH_PAGES } from '@/constants/github';
 import { getRandomNumber, getRandomItem } from '@/utils/random';
 import { GithubRepository, GithubSearchResponse, ReadmeLink } from './types';
-import { searchGithubRepositories, getRepositoryReadme } from './helpers';
+import { searchGithubRepositories, getRepositoryReadme } from '../api/helpers';
 
 const ABSOLUTE_URL_REGEX = /^(?:[a-z]+:)?\/\//i;
 const TRAILING_SLASHES_REGEX = /\/+$/;


### PR DESCRIPTION
Resolves #8

## Changes Made
- Move `services/github/helpers.ts` to `services/api/helpers.ts`.
- Refactor imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization to improve module structure and dependencies.

**Note:** This release contains no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->